### PR TITLE
Update version to 0.10.10 in pyproject.toml and __init__.py; improve …

### DIFF
--- a/chromhandler/__init__.py
+++ b/chromhandler/__init__.py
@@ -55,4 +55,4 @@ def __getattr__(name: str) -> Handler:
 
 __all__ = ["Handler", "ChromAnalyzer", "Molecule", "Protein", "to_enzymeml"]
 
-__version__ = "0.10.9"
+__version__ = "0.10.10"

--- a/chromhandler/readers/asm.py
+++ b/chromhandler/readers/asm.py
@@ -132,17 +132,34 @@ class ASMReader(AbstractReader):
         else:
             raise ValueError(f"Unit '{time_unit}' not recognized")
 
-        try:
-            peak_list = meas_document["peak list"]["peak"]
-        except KeyError:
-            analyte_document = doc[0]["analyte aggregate document"]["analyteDocument"]
+        peak_list = None
+        peak_block = meas_document.get("peak list")
+        if isinstance(peak_block, dict):
+            peaks = peak_block.get("peak")
+            if isinstance(peaks, list):
+                peak_list = peaks
 
-            if len(analyte_document) > 1:
-                logger.warning(
-                    f"More than one analyte document found in '{path}'. Using the first analyte document only."
-                )
+        doc_entry = doc[0]
+        if peak_list is None and isinstance(doc_entry, dict):
+            analyte_aggregate = doc_entry.get("analyte aggregate document")
+            analyte_document = None
+            if isinstance(analyte_aggregate, dict):
+                analyte_document = analyte_aggregate.get("analyteDocument")
 
-            peak_list = analyte_document[0]["peak list"]["peak"]
+            if isinstance(analyte_document, list) and analyte_document:
+                if len(analyte_document) > 1:
+                    logger.warning(
+                        f"More than one analyte document found in '{path}'. Using the first analyte document only."
+                    )
+
+                analyte_peak_block = analyte_document[0].get("peak list")
+                if isinstance(analyte_peak_block, dict):
+                    peaks = analyte_peak_block.get("peak")
+                    if isinstance(peaks, list):
+                        peak_list = peaks
+
+        if peak_list is None:
+            peak_list = []
 
         peaks = [self.map_peaks(peak) for peak in peak_list]
 

--- a/chromhandler/readers/shimadzu.py
+++ b/chromhandler/readers/shimadzu.py
@@ -28,26 +28,6 @@ class ShimadzuReader(AbstractReader):
         if len(self.file_paths) == 0:
             raise ValueError("No files found. Is the directory empty?")
 
-        # #region agent log
-        import json
-
-        with open("/Users/max/code/aldol_addition/.cursor/debug.log", "a") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "sessionId": "debug-session",
-                        "runId": "post-fix",
-                        "hypothesisId": "A",
-                        "location": "shimadzu.py:32",
-                        "message": "Using file_paths directly (no string sort)",
-                        "data": {"file_paths": self.file_paths, "values": self.values},
-                        "timestamp": __import__("time").time() * 1000,
-                    }
-                )
-                + "\n"
-            )
-        # #endregion
-
         measurements = []
         # Use self.file_paths directly - they are already sorted numerically by abstractreader.py
         for i, file in enumerate(self.file_paths):
@@ -71,31 +51,6 @@ class ShimadzuReader(AbstractReader):
 
             dilution_factor = sample_dict.get("Dilution Factor", 1)
             injection_volume = sample_dict.get("Injection Volume")
-
-            # #region agent log
-            import json
-
-            with open("/Users/max/code/aldol_addition/.cursor/debug.log", "a") as f:
-                f.write(
-                    json.dumps(
-                        {
-                            "sessionId": "debug-session",
-                            "runId": "post-fix",
-                            "hypothesisId": "C",
-                            "location": "shimadzu.py:55",
-                            "message": "Mapping file to value",
-                            "data": {
-                                "i": i,
-                                "file": file,
-                                "value": self.values[i],
-                                "all_values": self.values,
-                            },
-                            "timestamp": __import__("time").time() * 1000,
-                        }
-                    )
-                    + "\n"
-                )
-            # #endregion
 
             data = Data(
                 value=self.values[i],
@@ -316,29 +271,6 @@ class ShimadzuReader(AbstractReader):
                 continue
 
             files.append(str(file_path.absolute()))
-
-        # #region agent log
-        import json
-
-        with open("/Users/max/code/aldol_addition/.cursor/debug.log", "a") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "sessionId": "debug-session",
-                        "runId": "run1",
-                        "hypothesisId": "D",
-                        "location": "shimadzu.py:264",
-                        "message": "File collection in _get_file_paths",
-                        "data": {
-                            "files": files,
-                            "values": self.values if hasattr(self, "values") else None,
-                        },
-                        "timestamp": __import__("time").time() * 1000,
-                    }
-                )
-                + "\n"
-            )
-        # #endregion
 
         assert (
             len(files) == len(self.values)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { text = "MIT" }
 name = "chromhandler"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
-version = "0.10.9"
+version = "0.10.10"
 
 [build-system]
 build-backend = "hatchling.build"

--- a/tests/test_readers/test_asm.py
+++ b/tests/test_readers/test_asm.py
@@ -121,3 +121,36 @@ def test_read_asm_gc(asm_gc_1: ASMReader) -> None:
     assert measurements[0].chromatograms[0].peaks[0].area == pytest.approx(
         316139.0365283202, rel=1e-3
     )
+
+
+def test_missing_peak_list_returns_empty_peaks(asm_lc_1: ASMReader) -> None:
+    content = {
+        "liquid chromatography aggregate document": {
+            "liquid chromatography document": [
+                {
+                    "sample document": {
+                        "sample identifier": "",
+                        "written name": "broken",
+                    },
+                    "measurement document": {
+                        "chromatogram data cube": {
+                            "cube-structure": {
+                                "dimensions": [
+                                    {"unit": "s"},
+                                ]
+                            },
+                            "data": {
+                                "measures": [[1.0, 2.0]],
+                                "dimensions": [[1.0, 2.0]],
+                            },
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    measurement = asm_lc_1._map_lc_measurement(content, 0.0, "broken.json")
+    assert measurement.id == "broken"
+    assert len(measurement.chromatograms) == 1
+    assert measurement.chromatograms[0].peaks == []


### PR DESCRIPTION
…peak list handling in ASMReader for better robustness and add test for missing peak list scenario.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small robustness change to ASM LC parsing plus a targeted regression test; primary behavior change is returning empty peaks instead of raising when peak lists are missing.
> 
> **Overview**
> Bumps the library version to `0.10.10` in `pyproject.toml` and `chromhandler/__init__.py`.
> 
> Improves `ASMReader` LC parsing to **gracefully handle missing/variant peak list locations** by checking both `measurement document` and `analyte aggregate document` via safe lookups and defaulting to an empty peak list when absent.
> 
> Removes temporary debug logging from `ShimadzuReader` and adds a regression test ensuring LC measurements with no peak list produce `chromatograms[0].peaks == []`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 505625af9d9d7f453d8c96045160fcf2191e3e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->